### PR TITLE
Fixes for BSP live mode

### DIFF
--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -35,7 +35,7 @@ func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *Repl
 	sHash := block.Hash().String()
 
 	if atomic.LoadUint32(replicaConfig.HistoricalBlocksSynced) == 0 {
-		log.Info("BSP running in Live mode", "Unexported block ", block.NumberU64(), "hash", sHash)
+		//log.Info("BSP running in Live mode", "Unexported block ", block.NumberU64(), "hash", sHash)
 		return nil
 	} else if atomic.LoadUint32(replicaConfig.HistoricalBlocksSynced) == 1 {
 		log.Info("Creating Block Specimen", "Exported block", block.NumberU64(), "hash", sHash)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1673,10 +1673,11 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 
 		switch status {
 		case CanonStatTy:
-			log.Info("Inserted new block", "number", block.Number(), "hash", block.Hash(),
+			log.Debug("Inserted new block", "number", block.Number(), "hash", block.Hash(),
 				"uncles", len(block.Uncles()), "txs", len(block.Transactions()), "gas", block.GasUsed(),
 				"elapsed", common.PrettyDuration(time.Since(start)),
 				"root", block.Root())
+			// Handle creation of block specimen for canonical blocks
 			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
 			lastCanon = block
 
@@ -1684,11 +1685,12 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 			bc.gcproc += proctime
 
 		case SideStatTy:
-			log.Info("Inserted forked block", "number", block.Number(), "hash", block.Hash(),
+			log.Debug("Inserted forked block", "number", block.Number(), "hash", block.Hash(),
 				"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())
-			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			// Currently proof-chain is not handling the forked block use case hence commented out
+			//bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
 
 		default:
 			// This in theory is impossible, but lets be nice to our future selves and leave
@@ -1697,6 +1699,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 				"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())
+			// Is impossible but keeping in line to be nice to our future selves we add this for now
 			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
 		}
 		stats.processed++

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1673,7 +1673,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 
 		switch status {
 		case CanonStatTy:
-			log.Debug("Inserted new block", "number", block.Number(), "hash", block.Hash(),
+			log.Info("Inserted new block", "number", block.Number(), "hash", block.Hash(),
 				"uncles", len(block.Uncles()), "txs", len(block.Transactions()), "gas", block.GasUsed(),
 				"elapsed", common.PrettyDuration(time.Since(start)),
 				"root", block.Root())
@@ -1684,7 +1684,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 			bc.gcproc += proctime
 
 		case SideStatTy:
-			log.Debug("Inserted forked block", "number", block.Number(), "hash", block.Hash(),
+			log.Info("Inserted forked block", "number", block.Number(), "hash", block.Hash(),
 				"diff", block.Difficulty(), "elapsed", common.PrettyDuration(time.Since(start)),
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -365,11 +365,11 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 // SetHistoricalBlocksSynced returns a bool for BSP replica config (Historical mode :0 , Live mode: 1)
 func (b *EthAPIBackend) SetHistoricalBlocksSynced() bool {
 	if b.eth.Synced() {
-		atomic.StoreUint32(b.eth.ReplicaConfig.HistoricalBlocksSynced, 1)
-		log.Info("Fully Synced, BSP running in live sync mode", "BSP Mode Config: ", atomic.LoadUint32(b.eth.ReplicaConfig.HistoricalBlocksSynced))
+		atomic.StoreUint32(b.eth.blockchain.ReplicaConfig.HistoricalBlocksSynced, 1)
+		log.Info("Fully Synced, BSP running in live sync mode", "BSP Mode Config: ", atomic.LoadUint32(b.eth.blockchain.ReplicaConfig.HistoricalBlocksSynced))
 		return true
 	} else {
-		log.Error("Not accepting new transactions, BSP running in historical sync mode", "BSP Mode Config: ", atomic.LoadUint32(b.eth.ReplicaConfig.HistoricalBlocksSynced))
+		log.Error("Not accepting new transactions, BSP running in historical sync mode", "BSP Mode Config: ", atomic.LoadUint32(b.eth.blockchain.ReplicaConfig.HistoricalBlocksSynced))
 		return false
 	}
 }


### PR DESCRIPTION
Signed-off-by: Pranay Valson <pranay.valson@gmail.com>

* Live mode handles syncing without BSP export for most recently seen block by the source network's peer
* Sets the block replica config sync flag atomically and reads it to produce exports by switching between live (1) and historical (0) mode
* Does not yet handle the case for recreation of block specimens for forked blocks (not relevant for phase 1) as seen below -

```
INFO [03-29|19:32:33.780|core/blockchain.go:1676]          Inserted new block                       number=10,412,840 hash=46aed3..17c69b uncles=0 txs=102  gas=20,077,200 elapsed=48.348ms    root=e69ddf..bbb233
INFO [03-29|19:32:33.796|core/block_replica.go:41]         Creating Block Specimen                  Exported block=10,412,840 hash=0x46aed355f5c7e8fac91b4847a296978ac9440a239a65941f0dec4d4e3317c69b
INFO [03-29|19:32:33.796|core/blockchain_insert.go:74]     Imported new chain segment               blocks=1   txs=102  mgas=20.077  elapsed=65.093ms    mgasps=308.435 number=10,412,840 hash=46aed3..17c69b dirty=82.50MiB
INFO [03-29|19:32:33.797|core/rawdb/chain_iterator.go:338] Unindexed transactions                   blocks=1   txs=17   tail=8,062,841 elapsed="368.78µs"
INFO [03-29|19:32:36.301|core/blockchain.go:1688]          Inserted forked block                    number=10,412,840 hash=8db416..abcc52 diff=1 elapsed=34.252ms    txs=86   gas=20,002,823 uncles=0 root=66e928..6a83d1
INFO [03-29|19:32:36.301|core/blockchain_insert.go:74]     Imported new chain segment               blocks=1   txs=86   mgas=20.003  elapsed=35.362ms    mgasps=565.652 number=10,412,840 hash=8db416..abcc52 dirty=82.58MiB
INFO [03-29|19:32:36.948|core/blockchain.go:1688]          Inserted forked block                    number=10,412,840 hash=920abd..763181 diff=1 elapsed=42.288ms    txs=100  gas=27,194,708 uncles=0 root=aab7cc..6913be
INFO [03-29|19:32:36.948|core/blockchain_insert.go:74]     Imported new chain segment               blocks=1   txs=100  mgas=27.195  elapsed=43.820ms    mgasps=620.596 number=10,412,840 hash=920abd..763181 dirty=82.70MiB
ERROR[03-29|19:32:42.475|eth/handler.go:456]               Snapshot extension registration failed   peer=d515b6c0 err="peer connected on snap without compatible eth support"
INFO [03-29|19:32:48.164|core/rawdb/freezer.go:523]        Deep froze chain segment                 blocks=4   elapsed=4.892ms     number=10,322,840 hash=fa793e..f208b8

```




 

