### PR TITLE
disable light sync mode for bsp-geth

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.43
+          version: v1.45.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/cmd/geth/les_test.go
+++ b/cmd/geth/les_test.go
@@ -175,6 +175,7 @@ func startClient(t *testing.T, name string) *gethrpc {
 }
 
 func TestPriorityClient(t *testing.T) {
+	t.Skip() // skipping test which uses light sync mode
 	lightServer := startLightServer(t)
 	defer lightServer.killAndWait()
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -221,7 +221,7 @@ var (
 	defaultSyncMode = ethconfig.Defaults.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",
-		Usage: `Blockchain sync mode ("snap", "full" or "light")`,
+		Usage: `Blockchain sync mode ("snap" or "full")`,
 		Value: &defaultSyncMode,
 	}
 	GCModeFlag = cli.StringFlag{

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -30,7 +30,7 @@ const (
 
 func (mode SyncMode) IsValid() bool {
 	// not allowing light mode for bsp-geth as block specimen production in this mode is untested for now.
-	return mode >= FullSync && mode <= SnapSync
+	return mode >= FullSync && mode <= LightSync
 }
 
 // String implements the stringer interface.

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -29,7 +29,8 @@ const (
 )
 
 func (mode SyncMode) IsValid() bool {
-	return mode >= FullSync && mode <= LightSync
+	// not allowing light mode for bsp-geth as block specimen production in this mode is untested for now.
+	return mode >= FullSync && mode <= SnapSync
 }
 
 // String implements the stringer interface.
@@ -39,8 +40,8 @@ func (mode SyncMode) String() string {
 		return "full"
 	case SnapSync:
 		return "snap"
-	case LightSync:
-		return "light"
+	// case LightSync:
+	// 	return "light"
 	default:
 		return "unknown"
 	}
@@ -52,8 +53,8 @@ func (mode SyncMode) MarshalText() ([]byte, error) {
 		return []byte("full"), nil
 	case SnapSync:
 		return []byte("snap"), nil
-	case LightSync:
-		return []byte("light"), nil
+	// case LightSync:
+	// 	return []byte("light"), nil
 	default:
 		return nil, fmt.Errorf("unknown sync mode %d", mode)
 	}
@@ -65,10 +66,10 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = FullSync
 	case "snap":
 		*mode = SnapSync
-	case "light":
-		*mode = LightSync
+	// case "light":
+	// 	*mode = LightSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "full", "snap" or "light"`, text)
+		return fmt.Errorf(`unknown sync mode %q, want "full" or "snap"`, text)
 	}
 	return nil
 }


### PR DESCRIPTION
- snap and full modes work just fine. Block production might be faster
with light sync mode, but we're leaving it for future optimization.
- This PR just blocks the light usage from geth cli and keep the rest
of the code using the light mode intact. This is done to avoid big
merge conflicts when pulling upstream geth changes to this repo.