### PR TITLE
add other missing fields in block replica

### DIFF
--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -45,9 +45,14 @@ type ReceiptExportRLP struct {
 type TransactionForExport Transaction
 
 type TransactionExportRLP struct {
+	Type         byte            `json:"type"`
+	AccessList   AccessList      `json:"accessList"`
+	ChainId      *big.Int        `json:"chainId"`
 	AccountNonce uint64          `json:"nonce"`
 	Price        *big.Int        `json:"gasPrice"`
 	GasLimit     uint64          `json:"gas"`
+	GasTipCap    *big.Int        `json:"gasTipCap"`
+	GasFeeCap    *big.Int        `json:"gasFeeCap"`
 	Sender       common.Address  `json:"from"`
 	Recipient    *common.Address `json:"to" rlp:"nil"` // nil means contract creation
 	Amount       *big.Int        `json:"value"`
@@ -88,5 +93,10 @@ func (tx *TransactionForExport) ExportTx() *TransactionExportRLP {
 		Recipient:    txData.to(),
 		Amount:       txData.value(),
 		Payload:      txData.data(),
+		Type:         txData.txType(),
+		ChainId:      txData.chainID(),
+		AccessList:   txData.accessList(),
+		GasTipCap:    txData.gasTipCap(),
+		GasFeeCap:    txData.gasFeeCap(),
 	}
 }

--- a/core/types/block_specimen.go
+++ b/core/types/block_specimen.go
@@ -33,8 +33,8 @@ type codeRead struct {
 }
 
 type blockhashRead struct {
-	BlockN    uint64
-	BlockHash common.Hash
+	BlockNumber uint64
+	BlockHash   common.Hash
 }
 
 func NewStateSpecimen() *StateSpecimen {
@@ -96,8 +96,8 @@ func (sp *StateSpecimen) LogBlockhashRead(blockN uint64, blockHash common.Hash) 
 	log.Trace("Retrieved BlockHash", "block_number", blockN, "hash", blockHash)
 
 	sp.BlockhashRead = append(sp.BlockhashRead, &blockhashRead{
-		BlockN:    blockN,
-		BlockHash: blockHash,
+		BlockNumber: blockN,
+		BlockHash:   blockHash,
 	})
 
 	return sp


### PR DESCRIPTION
- accessList, chainId, type, gasTipCap, gasFeeCap are fields which need to be
  added in block_replica