### PR TITLE
adding senders field in block specimen export

### DIFF
--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -131,7 +131,7 @@ func (bc *BlockChain) createReplica(block *types.Block, replicaConfig *ReplicaCo
 			Transactions: txsRlp,
 			Uncles:       uncles,
 			Receipts:     []*types.ReceiptExportRLP{},
-			Senders:      []common.Address{},
+			Senders:      senders,
 			State:        stateSpecimen,
 		}
 		log.Debug("Exporting block-specimen only")


### PR DESCRIPTION
In order to avoid expensive sender recovery when executing the block specimen to produce block results