### PR TITLE
Update client identifier

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -48,7 +48,7 @@ import (
 )
 
 const (
-	clientIdentifier = "bspgeth" // Client identifier to advertise over the network
+	clientIdentifier = "geth" // Client identifier to advertise over the network
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Pranay Valson <pranay.valson@gmail.com>

Production nodes sync are affected by the client name identifier being used as a base data directory name identifier creating a separate directory which starts a fresh sync
```
root@cqt-bsp-operator-p2:/scratch/node/eth-mainnet# du -sh *
40G	bspgeth
984G	geth
0	geth.ipc
4.0K	keystore


root@cqt-bsp-operator-p2:/scratch/node/eth-mainnet# ls -las
total 20
4 drwxr-xr-x 5 blockchain blockchain 4096 Jan 30 20:21 .
4 drwxr-xr-x 3 root       root       4096 Jun 16  2022 ..
4 drwx------ 6 blockchain blockchain 4096 Jan 30 20:21 bspgeth
4 drwx------ 8 blockchain blockchain 4096 Jan 30 20:22 geth
4 drwx------ 2 blockchain blockchain 4096 Apr 14  2022 keystore
```

to avoid this issue we move the client name back to original