### PR TITLE
Update Github workflows for `develop`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    target-branch: "develop"
     reviewers:
       - "noslav"
+      - "sudeepdino008"
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,11 +2,12 @@ name: build-test
 
 on:
   push:
-    branches: 
-      - main 
-  pull_request:
     branches:
-      - main
+    - "main"
+  pull_request:
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   audit:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,12 @@ name: docker-image-ci
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "main"
   pull_request:
-    branches: [ main ]
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   push-image:

--- a/.github/workflows/gcr-image.yml
+++ b/.github/workflows/gcr-image.yml
@@ -2,7 +2,12 @@ name: gcr-image
 
 on:
   push:
-    branches: [main]
+    branches:
+    - "main"
+  pull_request:
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   build:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,9 +2,12 @@ name: golangci-lint
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - "main"
   pull_request:
-    branches: [ main ]
+    branches: 
+    - "main"
+    - "develop"
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,11 +2,12 @@ name: dockerfile-lint
 
 on:
   push:
-    branches: 
-      - main
-  pull_request:
     branches:
-      - main
+    - "main"
+  pull_request:
+    branches: 
+    - "main"
+    - "develop"
 
 jobs:
   linter:


### PR DESCRIPTION
* Moving towards new  development workflow with unstable feature testing and updates to `develop` (no CI/CD run on push but only on PR to `develop`)
* Post testing and results gathering creating another PR to merge `develop` to `main` with release tag candidate number
* Apply all actions on push and PR to `main` 
* Make sure all tests pass for PR develop -> main + testing is stable on `node-bsp-1` with `develop` 
* Merge develop -> main PR 
* Make stable release with `tag-release.yml` on `main` 