### PR TITLE
fixing gasPrice field value for dynamic tx

### DIFF
--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -75,7 +75,7 @@ func (bc *BlockChain) createReplica(block *types.Block, replicaConfig *ReplicaCo
 	txsRlp := make([]*types.TransactionExportRLP, len(block.Transactions()))
 	for i, tx := range block.Transactions() {
 		txsExp[i] = (*types.TransactionForExport)(tx)
-		txsRlp[i] = txsExp[i].ExportTx(chainConfig, block.Number())
+		txsRlp[i] = txsExp[i].ExportTx(chainConfig, block.Number(), header.BaseFee)
 		if !replicaConfig.EnableSpecimen {
 			txsRlp[i].V, txsRlp[i].R, txsRlp[i].S = nil, nil, nil
 		}

--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -78,7 +78,7 @@ func (r *ReceiptForExport) ExportReceipt() *ReceiptExportRLP {
 	return enc
 }
 
-func (tx *TransactionForExport) ExportTx(chainConfig *params.ChainConfig, blockNumber *big.Int) *TransactionExportRLP {
+func (tx *TransactionForExport) ExportTx(chainConfig *params.ChainConfig, blockNumber *big.Int, baseFee *big.Int) *TransactionExportRLP {
 	var inner_tx *Transaction = (*Transaction)(tx)
 	v, r, s := tx.inner.rawSignatureValues()
 	var signer Signer = MakeSigner(chainConfig, blockNumber)
@@ -88,7 +88,7 @@ func (tx *TransactionForExport) ExportTx(chainConfig *params.ChainConfig, blockN
 
 	return &TransactionExportRLP{
 		AccountNonce: txData.nonce(),
-		Price:        txData.gasPrice(),
+		Price:        txData.effectiveGasPrice(&big.Int{}, baseFee),
 		GasLimit:     txData.gas(),
 		Sender:       &from,
 		Recipient:    txData.to(),


### PR DESCRIPTION
- as specified by [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), the gasPrice has to be "effective gas price" as specified in the EIP.
- for legacy (or access) tx, "gasPrice" field value is simply returned.