### PR TITLE
adding support for eip-4895: withdrawals field

### DIFF
--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -81,6 +81,14 @@ func (bc *BlockChain) createReplica(block *types.Block, replicaConfig *ReplicaCo
 		}
 	}
 
+	// withdrawals
+	withdrawalsExp := make([]*types.WithdrawalForExport, len(block.Withdrawals()))
+	withdrawalsRlp := make([]*types.WithdrawalExportRLP, len(block.Withdrawals()))
+	for i, withdrawal := range block.Withdrawals() {
+		withdrawalsExp[i] = (*types.WithdrawalForExport)(withdrawal)
+		withdrawalsRlp[i] = withdrawalsExp[i].ExportWithdrawal()
+	}
+
 	//receipts
 	receipts := rawdb.ReadRawReceipts(bc.db, bHash, bNum)
 	receiptsExp := make([]*types.ReceiptForExport, len(receipts))
@@ -118,6 +126,7 @@ func (bc *BlockChain) createReplica(block *types.Block, replicaConfig *ReplicaCo
 			Receipts:     receiptsRlp,
 			Senders:      senders,
 			State:        stateSpecimen,
+			Withdrawals:  withdrawalsRlp,
 		}
 		log.Debug("Exporting full block-replica")
 		return exportBlockReplica, nil
@@ -133,6 +142,7 @@ func (bc *BlockChain) createReplica(block *types.Block, replicaConfig *ReplicaCo
 			Receipts:     []*types.ReceiptExportRLP{},
 			Senders:      senders,
 			State:        stateSpecimen,
+			Withdrawals:  withdrawalsRlp,
 		}
 		log.Debug("Exporting block-specimen only")
 		return exportBlockReplica, nil

--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -18,6 +18,7 @@ type ExportBlockReplica struct {
 	Receipts     []*ReceiptExportRLP
 	Senders      []common.Address
 	State        *StateSpecimen
+	Withdrawals  []*WithdrawalExportRLP
 }
 
 type LogsExportRLP struct {
@@ -41,6 +42,15 @@ type ReceiptExportRLP struct {
 	ContractAddress   common.Address
 	Logs              []*LogsExportRLP
 	GasUsed           uint64
+}
+
+type WithdrawalForExport Withdrawal
+
+type WithdrawalExportRLP struct {
+	Index     uint64         `json:"index"`          // monotonically increasing identifier issued by consensus layer
+	Validator uint64         `json:"validatorIndex"` // index of validator associated with withdrawal
+	Address   common.Address `json:"address"`        // target address for withdrawn ether
+	Amount    uint64         `json:"amount"`         // value of withdrawal in Gwei
 }
 
 type TransactionForExport Transaction
@@ -76,6 +86,15 @@ func (r *ReceiptForExport) ExportReceipt() *ReceiptExportRLP {
 		enc.Logs[i] = (*LogsExportRLP)(log)
 	}
 	return enc
+}
+
+func (r *WithdrawalForExport) ExportWithdrawal() *WithdrawalExportRLP {
+	return &WithdrawalExportRLP{
+		Index:     r.Index,
+		Validator: r.Validator,
+		Address:   r.Address,
+		Amount:    r.Amount,
+	}
 }
 
 func (tx *TransactionForExport) ExportTx(chainConfig *params.ChainConfig, blockNumber *big.Int) *TransactionExportRLP {


### PR DESCRIPTION
- system level operation added which allows to withdraw the staked ether (https://eips.ethereum.org/EIPS/eip-4895)
- `withdrawlsHashRoot` was already added in a previous change