### PR TITLE
Migrate `bsp-geth` build docker images from GCR to GAR

### DIFF
--- a/.github/workflows/gcr-image.yml
+++ b/.github/workflows/gcr-image.yml
@@ -3,11 +3,11 @@ name: gcr-image
 on:
   push:
     branches:
-    - "main"
+      - "main"
   pull_request:
-    branches: 
-    - "main"
-    - "develop"
+    branches:
+      - "main"
+      - "develop"
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
       - name: Login to GCR
         uses: docker/login-action@v2
         with:
-          registry: gcr.io
+          registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
@@ -24,4 +24,4 @@ jobs:
       # - uses: satackey/action-docker-layer-caching@v0.0.11
       - name: Build & Publish the Docker image
         run: |
-          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --platform=linux/amd64,linux/arm64 . -t gcr.io/covalent-project/bsp-geth:latest --push
+          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --platform=linux/amd64,linux/arm64 . -t us-docker.pkg.dev/covalent-project/network/bsp-geth:latest --push

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Login to GCR
         uses: docker/login-action@v2
         with:
-          registry: gcr.io
+          registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build & Publish the Docker image
         run: |
-          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --platform=linux/amd64,linux/arm64 . -t gcr.io/covalent-project/bsp-geth:stable -t gcr.io/covalent-project/bsp-geth:"${{ env.TAG }}" --push
+          docker buildx create --name builder --use --platform=linux/amd64,linux/arm64  && docker buildx build --platform=linux/amd64,linux/arm64 . -t us-docker.pkg.dev/covalent-project/network/bsp-geth:stable -t us-docker.pkg.dev/covalent-project/network/bsp-geth:"${{ env.TAG }}" --push
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
@@ -37,4 +37,3 @@ jobs:
           files: |
             *.zip
             *.tar.gz
-          


### PR DESCRIPTION
* GCR deprecated in favour of default GAR