### PR TITLE
Complete EIP-4844 blob export support (Ethereum Migration v1.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ logs/
 coverage.out
 coverage.txt
 tests/spec-tests/
+bin/

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -104,6 +104,7 @@ if one is set.  Otherwise it prints the genesis from the datadir.`,
 			utils.BlockReplicationTargetsFlag,
 			utils.ReplicaEnableSpecimenFlag,
 			utils.ReplicaEnableResultFlag,
+			utils.ReplicaEnableBlobFlag,
 		}, utils.DatabaseFlags),
 		Description: `
 The import command imports blocks from an RLP-encoded form. The form can be one file

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -149,6 +149,7 @@ var (
 		utils.BlockReplicationTargetsFlag,
 		utils.ReplicaEnableResultFlag,
 		utils.ReplicaEnableSpecimenFlag,
+		utils.ReplicaEnableBlobFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 
 	rpcFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -694,6 +694,10 @@ var (
 		Name:  "replica.result",
 		Usage: "Enables export of fields that comprise a block-result",
 	}
+	ReplicaEnableBlobFlag = &cli.BoolFlag{
+		Name:  "replica.blob",
+		Usage: "Enables export of fields that comprise a block-blob",
+	}
 	BatchRequestLimit = &cli.IntFlag{
 		Name:     "rpc.batch-request-limit",
 		Usage:    "Maximum number of requests in a batch",
@@ -2188,8 +2192,11 @@ func setBlockReplicationTargets(ctx *cli.Context, cfg *eth.Config) {
 		if ctx.Bool(ReplicaEnableResultFlag.Name) {
 			cfg.ReplicaEnableResult = true
 		}
+		if ctx.Bool(ReplicaEnableBlobFlag.Name) {
+			cfg.ReplicaEnableBlob = true
+		}
 	} else {
-		Fatalf("--replication.targets flag is invalid without --replica.specimen and/or --replica.result")
+		Fatalf("--replication.targets flag is invalid without --replica.specimen and/or --replica.result, ONLY ADD --replica.blob with both replica.specimen AND replica.result flags for complete unified state capture)")
 	}
 }
 

--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -24,21 +24,21 @@ func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *Repl
 
 	var blobTxSidecars []*types.BlobTxSidecar
 	for sidecarData := range types.BlobTxSidecarChan {
-		// if sidecarData.BlockNumber == block.Header().Number {
-		// 	log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
-		// 	blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
-		// } else {
-		// 	log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber)
-		// }
+		if sidecarData.BlockNumber.Uint64() == block.NumberU64() {
+			log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
+			blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
+		} else {
+			log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber.Uint64())
+		}
 		fmt.Println("side car header block number:", sidecarData.BlockNumber)
 		fmt.Println("length of sidecar channel:", len(types.BlobTxSidecarChan))
 
-		blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
+		// blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
 	}
 
-	for _, sidecarData := range blobTxSidecars {
-		fmt.Println(*sidecarData, "full side car")
-	}
+	// for _, sidecarData := range blobTxSidecars {
+	// 	fmt.Println(*sidecarData, "full side car")
+	// }
 
 	//block replica
 	exportBlockReplica, err := bc.createReplica(block, replicaConfig, chainConfig, stateSpecimen, blobTxSidecars)

--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -24,14 +24,16 @@ func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *Repl
 
 	var blobTxSidecars []*types.BlobTxSidecar
 	for sidecarData := range types.BlobTxSidecarChan {
-		if sidecarData.BlockNumber == block.Header().Number {
-			log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
-			blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
-		} else {
-			log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber)
-		}
-		fmt.Println(sidecarData.BlockNumber, "side car header block number")
-		fmt.Println("length of sidecar channel", len(types.BlobTxSidecarChan))
+		// if sidecarData.BlockNumber == block.Header().Number {
+		// 	log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
+		// 	blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
+		// } else {
+		// 	log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber)
+		// }
+		fmt.Println("side car header block number:", sidecarData.BlockNumber)
+		fmt.Println("length of sidecar channel:", len(types.BlobTxSidecarChan))
+
+		blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
 	}
 
 	for _, sidecarData := range blobTxSidecars {

--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -26,16 +26,16 @@ func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *Repl
 	for sidecarData := range types.BlobTxSidecarChan {
 		if sidecarData.BlockNumber == block.Header().Number {
 			log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
-			blobTxSidecars = append(blobTxSidecars, sidecarData.Sidecar...)
+			blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
 		} else {
 			log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber)
 		}
 		fmt.Println(sidecarData.BlockNumber, "side car header block number")
-		fmt.Println(sidecarData.ParentBeaconRoot, "side car parent beacon block root")
+		fmt.Println("length of sidecar channel", len(types.BlobTxSidecarChan))
 	}
 
-	for sideCar := range blobTxSidecars {
-		fmt.Println(sideCar, "full side car")
+	for _, sidecarData := range blobTxSidecars {
+		fmt.Println(*sidecarData, "full side car")
 	}
 
 	//block replica

--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -22,25 +22,23 @@ type BlockReplicationEvent struct {
 
 func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *ReplicaConfig, chainConfig *params.ChainConfig, stateSpecimen *types.StateSpecimen) error {
 
+	// blobs
 	var blobTxSidecars []*types.BlobTxSidecar
 	for sidecarData := range types.BlobTxSidecarChan {
 		if sidecarData.BlockNumber.Uint64() == block.NumberU64() {
-			log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
+			log.Info("Consuming BlobTxSidecar Match From Chain Sync Channel", "Block Number:", sidecarData.BlockNumber.Uint64())
 			blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
 		} else {
-			log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber.Uint64())
+			log.Info("Failing BlobTxSidecar Match from Chain Sync Channel", "Block Number:", sidecarData.BlockNumber.Uint64())
 		}
-		fmt.Println("side car header block number:", sidecarData.BlockNumber)
-		fmt.Println("length of sidecar channel:", len(types.BlobTxSidecarChan))
 
-		// blobTxSidecars = append(blobTxSidecars, sidecarData.Blobs)
+		log.Info("BlobTxSidecar Header", "Block Number:", sidecarData.BlockNumber.Uint64())
+
+		log.Info("Chain Sync Sidecar Channel", "Length:", len(types.BlobTxSidecarChan))
+
 	}
 
-	// for _, sidecarData := range blobTxSidecars {
-	// 	fmt.Println(*sidecarData, "full side car")
-	// }
-
-	//block replica
+	//block replica with blobs
 	exportBlockReplica, err := bc.createReplica(block, replicaConfig, chainConfig, stateSpecimen, blobTxSidecars)
 	if err != nil {
 		return err

--- a/core/block_replica.go
+++ b/core/block_replica.go
@@ -25,9 +25,17 @@ func (bc *BlockChain) createBlockReplica(block *types.Block, replicaConfig *Repl
 	var blobTxSidecars []*types.BlobTxSidecar
 	for sidecarData := range types.BlobTxSidecarChan {
 		if sidecarData.BlockNumber == block.Header().Number {
-			fmt.Println("Consuming Sidecar From Miner Side Channel", sidecarData.BlockNumber)
+			log.Info("Consuming Sidecar From Miner Side Channel: ", sidecarData.BlockNumber)
 			blobTxSidecars = append(blobTxSidecars, sidecarData.Sidecar...)
+		} else {
+			log.Info("Blob Sidecar did not match block number from Miner Side Channel: ", sidecarData.BlockNumber)
 		}
+		fmt.Println(sidecarData.BlockNumber, "side car header block number")
+		fmt.Println(sidecarData.ParentBeaconRoot, "side car parent beacon block root")
+	}
+
+	for sideCar := range blobTxSidecars {
+		fmt.Println(sideCar, "full side car")
 	}
 
 	//block replica

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1851,7 +1851,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 
 		if !setHead {
 			// Export Block Specimen
-			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			if bc.ReplicaConfig.EnableSpecimen || bc.ReplicaConfig.EnableResult {
+				bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			}
 			// After merge we expect few side chains. Simply count
 			// all blocks the CL gives us for GC processing time
 			bc.gcproc += proctime
@@ -1865,7 +1867,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 				"elapsed", common.PrettyDuration(time.Since(start)),
 				"root", block.Root())
 			// Handle creation of block specimen for canonical blocks
-			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			if bc.ReplicaConfig.EnableSpecimen || bc.ReplicaConfig.EnableResult {
+				bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			}
 			lastCanon = block
 
 			// Only count canonical blocks for GC processing time

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -267,6 +267,7 @@ type BlockChain struct {
 type ReplicaConfig struct {
 	EnableSpecimen         bool
 	EnableResult           bool
+	EnableBlob             bool
 	HistoricalBlocksSynced *uint32
 }
 
@@ -315,6 +316,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, genesis *Genesis
 		ReplicaConfig: &ReplicaConfig{
 			EnableSpecimen:         false,
 			EnableResult:           false,
+			EnableBlob:             false,
 			HistoricalBlocksSynced: new(uint32), // Always set 0 for historical mode at start
 		},
 	}
@@ -1891,7 +1893,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool) (int, error)
 				"txs", len(block.Transactions()), "gas", block.GasUsed(), "uncles", len(block.Uncles()),
 				"root", block.Root())
 			// Is impossible but keeping in line to be nice to our future selves we add this for now
-			bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			if bc.ReplicaConfig.EnableSpecimen || bc.ReplicaConfig.EnableResult {
+				bc.createBlockReplica(block, bc.ReplicaConfig, bc.chainConfig, statedb.TakeStateSpecimen())
+			}
 		}
 	}
 

--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -78,9 +78,8 @@ type TransactionExportRLP struct {
 }
 
 type BlobTxSidecarData struct {
-	Sidecar          []*BlobTxSidecar
-	BlockNumber      *big.Int
-	ParentBeaconRoot *common.Hash
+	Blobs       *BlobTxSidecar
+	BlockNumber *big.Int
 }
 
 var BlobTxSidecarChan = make(chan *BlobTxSidecarData, 1000)

--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -78,8 +78,9 @@ type TransactionExportRLP struct {
 }
 
 type BlobTxSidecarData struct {
-	Sidecar     []*BlobTxSidecar
-	BlockNumber *big.Int
+	Sidecar          []*BlobTxSidecar
+	BlockNumber      *big.Int
+	ParentBeaconRoot *common.Hash
 }
 
 var BlobTxSidecarChan = make(chan *BlobTxSidecarData, 1000)

--- a/core/types/block_export.go
+++ b/core/types/block_export.go
@@ -82,7 +82,7 @@ type BlobTxSidecarData struct {
 	BlockNumber *big.Int
 }
 
-var BlobTxSidecarChan = make(chan *BlobTxSidecarData, 1000)
+var BlobTxSidecarChan = make(chan *BlobTxSidecarData, 100)
 
 func (r *ReceiptForExport) ExportReceipt() *ReceiptExportRLP {
 	enc := &ReceiptExportRLP{

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -177,6 +177,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		ReplicaConfig: &core.ReplicaConfig{
 			EnableSpecimen:         config.ReplicaEnableSpecimen,
 			EnableResult:           config.ReplicaEnableResult,
+			EnableBlob:             config.ReplicaEnableBlob,
 			HistoricalBlocksSynced: new(uint32), // Always set 0 for historical mode at start
 		},
 	}
@@ -186,7 +187,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		if err != nil {
 			return nil, err
 		}
-		log.Info("Block replication started", "targets", targets, "network ID", config.NetworkId, "export block-specimen", eth.ReplicaConfig.EnableSpecimen, "export block-result", eth.ReplicaConfig.EnableResult)
+		log.Info("Block replication started", "targets", targets, "network ID", config.NetworkId, "export block-specimen", eth.ReplicaConfig.EnableSpecimen, "export block-result", eth.ReplicaConfig.EnableResult, "export blob-specimen", eth.ReplicaConfig.EnableBlob)
 		eth.blockReplicators = append(eth.blockReplicators, replicator)
 	}
 	bcVersion := rawdb.ReadDatabaseVersion(chainDb)

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -160,6 +160,7 @@ type Config struct {
 	// Bools that make explicit types being exported
 	ReplicaEnableResult   bool
 	ReplicaEnableSpecimen bool
+	ReplicaEnableBlob     bool
 
 	// OverrideCancun (TODO: remove after the fork)
 	OverrideCancun *uint64 `toml:",omitempty"`

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -118,8 +118,9 @@ func (env *environment) copy() *environment {
 
 	go func() {
 		types.BlobTxSidecarChan <- &types.BlobTxSidecarData{
-			Sidecar:     env.sidecars,
-			BlockNumber: env.header.Number,
+			Sidecar:          env.sidecars,
+			BlockNumber:      env.header.Number,
+			ParentBeaconRoot: env.header.ParentBeaconRoot,
 		}
 	}()
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -116,6 +116,13 @@ func (env *environment) copy() *environment {
 	cpy.sidecars = make([]*types.BlobTxSidecar, len(env.sidecars))
 	copy(cpy.sidecars, env.sidecars)
 
+	go func() {
+		types.BlobTxSidecarChan <- &types.BlobTxSidecarData{
+			Sidecar:     env.sidecars,
+			BlockNumber: env.header.Number,
+		}
+	}()
+
 	return cpy
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -118,7 +118,7 @@ func (env *environment) copy() *environment {
 	cpy.sidecars = make([]*types.BlobTxSidecar, len(env.sidecars))
 	copy(cpy.sidecars, env.sidecars)
 
-	types.BlobTxSidecarChan = make(chan *types.BlobTxSidecarData, 1000)
+	types.BlobTxSidecarChan = make(chan *types.BlobTxSidecarData, 100)
 
 	go func() {
 		for sidecar := range env.sidecars {
@@ -127,7 +127,7 @@ func (env *environment) copy() *environment {
 				BlockNumber: env.header.Number,
 			}
 		}
-		fmt.Println("closed sidecar channel in miner")
+		log.Info("Closing Chain Sync BlobTxSidecar Channel For", "Block Number:", env.header.Number.Uint64(), "Length:", len(types.BlobTxSidecarChan))
 		close(types.BlobTxSidecarChan)
 	}()
 

--- a/params/version.go
+++ b/params/version.go
@@ -29,7 +29,7 @@ const (
 
 const (
 	BspVersionMajor = 1 // Major version component of the current release
-	BspVersionMinor = 6 // Minor version component of the current release
+	BspVersionMinor = 8 // Minor version component of the current release
 	BspVersionPatch = 0 // Patch version component of the current release
 )
 


### PR DESCRIPTION
* Creates a channel for chain sync miner to push blob data
* Enable channel to accept blob based on `--replica.blob` flag provided as replication target
* Pushes BlobTxSidecar data into the channel with the corresponding block number
* Restructures replica segments to consume blob data and export block-specimens and block-results with blobs
* Adds support for additional type 3 tx fields like BlobFeeCap, BlobHashes and BlobGas 
* Passes tests and doesn't block validator chain sync